### PR TITLE
Feature/spark sql experimentation

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/MarkDuplicates.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/MarkDuplicates.scala
@@ -22,6 +22,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{ DataFrame, Dataset, SQLContext }
 import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.functions
+import org.apache.spark.sql.functions.{ first, when, sum, countDistinct }
 import org.bdgenomics.adam.instrumentation.Timers._
 import org.bdgenomics.adam.models.{ RecordGroupDictionary, ReferencePosition }
 import org.bdgenomics.adam.rdd.ADAMContext._
@@ -125,8 +126,6 @@ private[rdd] object MarkDuplicates extends Serializable with Logging {
       .withColumn("fivePrimePosition",
         fpUDF('readMapped, 'readNegativeStrand, 'cigar, 'start, 'end))
 
-    import org.apache.spark.sql.functions.{ first, when, sum }
-
     // 2. Group all fragments, finding read 1 & 2 reference positions
     val positionedDf = df
       .groupBy("recordGroupName", "readName")
@@ -179,16 +178,21 @@ private[rdd] object MarkDuplicates extends Serializable with Logging {
         'read2contigName, 'read2fivePrimePosition, 'read2strand)
       .orderBy('score.desc)
 
-    // Unmapped reads
-    val filteredDf = positionedDf.filter('read1fivePrimePosition.isNotNull) // count = 232,860 (not anymore)
+    // Discard unmapped left position reads
+    val filteredDf = positionedDf
+      .filter('read1contigName.isNotNull and 'read1fivePrimePosition.isNotNull and 'read1strand.isNotNull)
 
-    // Need to keet track of the ones that
-    val unmappedDf = positionedDf.filter('read1fivePrimePosition.isNull)
+    val unmappedDf = positionedDf
+      .withColumn("unmapped",
+        when(
+          'read1contigName.isNull and 'read1fivePrimePosition.isNull and 'read1strand.isNull, true)
+          .otherwise(false))
+      .select("recordGroupName", "readName", "unmapped")
 
-    // Figuring out which
+    // Count the number of groups of right-position-mapped fragments for each left position
     val groupCountDf = filteredDf
       .groupBy('library, 'read1contigName, 'read1fivePrimePosition, 'read1strand)
-      .agg(functions.countDistinct('read2contigName, 'read2fivePrimePosition, 'read2strand)
+      .agg(countDistinct('read2contigName, 'read2fivePrimePosition, 'read2strand)
         as 'groupCount)
 
     // Join in the group counts
@@ -203,38 +207,36 @@ private[rdd] object MarkDuplicates extends Serializable with Logging {
       .drop(groupCountDf("read1fivePrimePosition")).drop(groupCountDf("read1strand"))
 
     val duplicatesDf = joinedDf
-      .withColumn("duplicatedRead",
+      .withColumn("duplicateRead",
         functions.row_number.over(positionWindow) =!= 1 or
           ('read2contigName.isNull and 'read2fivePrimePosition.isNull and 'read2strand.isNull
             and 'groupCount > 0))
-      .filter('duplicatedRead)
-      .select("recordGroupName", "readName")
+      .select("recordGroupName", "readName", "duplicateRead")
 
-    // Convert to broadcast set
-    val duplicateSet = alignmentRecords.rdd.context
-      .broadcast(duplicatesDf.collect()
-        .map(row => (row(0), row(1))).toSet)
+    val finalDf = alignmentRecords.dataset
+    //    val schema = AlignmentRecord.getClassSchema
 
-    val unmappedSet = alignmentRecords.rdd.context
-      .broadcast(unmappedDf.collect()
-        .map(row => (row(0), row(1))).toSet)
+    val withDupsDf = finalDf
+      .drop("duplicateRead")
 
-//    val uhh = duplicatesDf.as[AlignmentRecordSchema]
-//      .rdd
+      .join(duplicatesDf,
+        finalDf("recordGroupName") === duplicatesDf("recordGroupName").alias("rgn1") and
+          finalDf("readName") === duplicatesDf("readName").alias("rn"))
+      .drop(duplicatesDf("recordGroupName")).drop(duplicatesDf("readName"))
 
-    // Mark all the duplicates that have been found
-    alignmentRecords.rdd
-      .map(read => {
-        val fragID = (read.getRecordGroupName, read.getReadName)
+    withDupsDf
+      .join(unmappedDf,
+        withDupsDf("recordGroupName") === unmappedDf("recordGroupName").alias("rgn2") and
+          withDupsDf("readName") === unmappedDf("readName").alias("rn"))
+      .drop(unmappedDf("recordGroupName")).drop(unmappedDf("readName"))
 
-        val isdup = duplicateSet.value.contains(fragID) ||
-          (
-            !unmappedSet.value.contains(fragID) &&
-            (read.getReadMapped && !read.primaryAlignment)
-          )
-        read.setDuplicateRead(isdup)
-        read
-      })
+      .withColumn("duplicateRead",
+        when('duplicateRead, true)
+          .otherwise(
+            when(!'unmapped and 'readMapped and !'primaryAlignment, true)
+              .otherwise(false)))
+      .as[AlignmentRecordSchema]
+      .rdd.map(read => read.toAvro)
 
     // todo: This is the old code
     // markBuckets(alignmentRecords.groupReadsByFragment(), alignmentRecords.recordGroups)

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/MarkDuplicates.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/MarkDuplicates.scala
@@ -135,6 +135,7 @@ private[rdd] object MarkDuplicates extends Serializable with Logging {
         //          .otherwise(first(when('readInFragment === 0, 'fivePrimePosition))) as 'read1RefPos,
         sum(when('primaryAlignment, scoreUDF('qual))) as 'score)
       .join(libraryDf(alignmentRecords.recordGroups), "recordGroupName")
+      .filter('read1RefPos.isNotNull)
 
     // Filtering by left position not being null here results in 1.5k duplicates not
     // being marked that would have been marked otherwise

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/MarkDuplicates.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/MarkDuplicates.scala
@@ -129,30 +129,19 @@ private[rdd] object MarkDuplicates extends Serializable with Logging {
     val positionedDf = df
       .groupBy("recordGroupName", "readName")
       .agg(
-        first(when('primaryAlignment and 'readInFragment === 0, 'fivePrimePosition)) as 'read1RefPos,
-        first(when('primaryAlignment and 'readInFragment === 1, 'fivePrimePosition)) as 'read2RefPos,
+        first(when('primaryAlignment and 'readInFragment === 0, 'fivePrimePosition), true) as 'read1RefPos,
+        first(when('primaryAlignment and 'readInFragment === 1, 'fivePrimePosition), true) as 'read2RefPos,
         sum(when('primaryAlignment, scoreUDF('qual))) as 'score)
       .join(libraryDf(alignmentRecords.recordGroups), "recordGroupName")
 
-    // debugging
-    val topRead1RefPos = positionedDf.orderBy('read1RefPos).take(10)
-
     // positionedDf.count = 514,303
-    val filteredDf = positionedDf.filter('read1RefPos.isNotNull) // count = 232,860
-
-    // debugging
-    val okay = positionedDf.groupBy('read1RefPos, 'library).agg(functions.countDistinct('read2RefPos)).count
-    log.warn(s"okay: $okay")
-
-    val topk = positionedDf.select('read1RefPos)
-      .orderBy('read1RefPos.desc)
-      .take(10)
+//    val filteredDf = positionedDf.filter('read1RefPos.isNotNull) // count = 232,860
 
     val positionWindow = Window
       .partitionBy('read1RefPos, 'read2RefPos, 'library)
       .orderBy('score.desc)
 
-    val duplicatesDf = filteredDf
+    val duplicatesDf = positionedDf
       .withColumn("duplicatedRead",
         functions.row_number.over(positionWindow) =!= 1)
       .filter('duplicatedRead)
@@ -168,7 +157,7 @@ private[rdd] object MarkDuplicates extends Serializable with Logging {
       .map(read => {
         val fragID = (read.getRecordGroupName, read.getReadName)
         read.setDuplicateRead(duplicateSet.value.contains(fragID)
-          || (read.getReadMapped && !read.getPrimaryAlignment))
+                  || (read.getReadMapped && !read.getPrimaryAlignment))
         read
       })
 

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/MarkDuplicates.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/MarkDuplicates.scala
@@ -132,30 +132,35 @@ private[rdd] object MarkDuplicates extends Serializable with Logging {
       .agg(
 
         // Read 1 Reference Position
-        first(when('primaryAlignment and 'readInFragment === 0, 'contigName), ignoreNulls = true)
+        first(when('primaryAlignment and 'readInFragment === 0,
+          when('readMapped, 'contigName).otherwise('sequence)),
+          ignoreNulls = true)
           as 'read1contigName,
 
-        first(when('primaryAlignment and 'readInFragment === 0, 'fivePrimePosition), ignoreNulls = true)
+        first(when('primaryAlignment and 'readInFragment === 0, 'fivePrimePosition),
+          ignoreNulls = true)
           as 'read1fivePrimePosition,
 
-        first(when('primaryAlignment and 'readInFragment === 0, 'readNegativeStrand), ignoreNulls = true)
+        first(when('primaryAlignment and 'readInFragment === 0, 'readNegativeStrand),
+          ignoreNulls = true)
           as 'read1readNegativeStrand,
 
         // Read 2 Reference Position
-        first(when('primaryAlignment and 'readInFragment === 1, 'contigName), ignoreNulls = true)
+        first(when('primaryAlignment and 'readInFragment === 1,
+          when('readMapped, 'contigName).otherwise('sequence)),
+          ignoreNulls = true)
           as 'read2contigName,
 
-        first(when('primaryAlignment and 'readInFragment === 1, 'fivePrimePosition), ignoreNulls = true)
+        first(when('primaryAlignment and 'readInFragment === 1, 'fivePrimePosition),
+          ignoreNulls = true)
           as 'read2fivePrimePosition,
 
-        first(when('primaryAlignment and 'readInFragment === 1, 'readNegativeStrand), ignoreNulls = true)
+        first(when('primaryAlignment and 'readInFragment === 1, 'readNegativeStrand),
+          ignoreNulls = true)
           as 'read2readNegativeStrand,
 
         sum(when('readMapped and 'primaryAlignment, scoreUDF('qual))) as 'score)
       .join(libraryDf(alignmentRecords.recordGroups), "recordGroupName")
-
-    val interestDf = positionedDf
-      .filter('readName === "HWI-D00684:221:HNWKCADXX:2:1213:7143:86120")
 
     // positionedDf.count = 514,303
     val positionWindow = Window

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/MarkDuplicates.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/MarkDuplicates.scala
@@ -137,7 +137,8 @@ private[rdd] object MarkDuplicates extends Serializable with Logging {
           ignoreNulls = true)
           as 'read1contigName,
 
-        first(when('primaryAlignment and 'readInFragment === 0, 'fivePrimePosition),
+        first(when('primaryAlignment and 'readInFragment === 0,
+          when('readMapped, 'fivePrimePosition).otherwise(0L)),
           ignoreNulls = true)
           as 'read1fivePrimePosition,
 
@@ -151,7 +152,8 @@ private[rdd] object MarkDuplicates extends Serializable with Logging {
           ignoreNulls = true)
           as 'read2contigName,
 
-        first(when('primaryAlignment and 'readInFragment === 1, 'fivePrimePosition),
+        first(when('primaryAlignment and 'readInFragment === 1,
+          when('readMapped, 'fivePrimePosition).otherwise(0L)),
           ignoreNulls = true)
           as 'read2fivePrimePosition,
 


### PR DESCRIPTION
Implemented duplicate marking in Spark SQL with about 30% performance gain and correctness. Still need to eliminate UDFs.